### PR TITLE
add option to specify version system

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,5 @@
 name: Integration Test
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,19 +7,19 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Self test
-        id: selftest
-        uses: jacobtomlinson/gha-anaconda-package-version@master
+        id: selftest-semver
+        uses: ./
         with:
           org: anaconda
           package: python
 
       - name: Check outputs
         run: |
-          echo "${{ steps.selftest.outputs.version }}"
+          echo "${{ steps.selftest-semver.outputs.version }}"
 
       - name: Self test
-        id: selftest
-        uses: jacobtomlinson/gha-anaconda-package-version@master
+        id: selftest-calver
+        uses: ./
         with:
           org: conda-forge
           package: pangeo-notebook
@@ -27,4 +27,4 @@ jobs:
 
       - name: Check outputs
         run: |
-          echo "${{ steps.selftest.outputs.version }}"
+          echo "${{ steps.selftest-calver.outputs.version }}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,3 +16,15 @@ jobs:
       - name: Check outputs
         run: |
           echo "${{ steps.selftest.outputs.version }}"
+
+      - name: Self test
+        id: selftest
+        uses: jacobtomlinson/gha-anaconda-package-version@master
+        with:
+          org: conda-forge
+          package: pangeo-notebook
+          version_system: CalVer
+
+      - name: Check outputs
+        run: |
+          echo "${{ steps.selftest.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -23,20 +23,22 @@ jobs:
       with:
         org: anaconda
         package: python
+        version_system: SemVer
 ```
 
 ### Inputs
 
-| Input                                             | Description                                        |
-|------------------------------------------------------|-----------------------------------------------|
-| `org`  | The Anaconda user or organization    |
-| `package` | The name of the Python package    |
+| Input            | Description                                                      |
+|------------------|------------------------------------------------------------------|
+| `org`            | The Anaconda user or organization                                |
+| `package`        | The name of the Python package                                   |
+| `version_system` | The name of the version system: `SemVer` (default) or  `CalVer`. |
 
 ### Outputs
 
-| Output                                             | Description                                        |
-|------------------------------------------------------|-----------------------------------------------|
-| `version`  | The version of the package    |
+| Output           | Description                                                      |
+|------------------|------------------------------------------------------------------|
+| `version`        | The version of the package                                       |
 
 ## Examples
 
@@ -57,6 +59,7 @@ jobs:
       with:
         org: anaconda
         package: python
+        version_system: SemVer
 
     - name: Check outputs
         run: |


### PR DESCRIPTION
We noticed today that this action only works for conda packages that use semver. When pointing to packages that use _CalVer_, the `SemVer` package strips leading zeros in dates. This PR adds the option to specify a `version_system` option: 

```yaml
name: My Workflow
on: push
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
    - name: Get latest Anaconda Python version
      id: anaconda
      uses: jacobtomlinson/gha-anaconda-package-version@master
      with:
        org: conda-forge
        package: pangeo-notebook
        version_system: SemVer
```
