### PR TITLE
Add release automation and instructions

### DIFF
--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -1,0 +1,19 @@
+# Automatically updates "vX" branches based on GitHub releases. To cut a new
+# release, use the GitHub UI where you enter a tag name and release name of
+# "vX.Y.Z". See https://github.com/jupyterhub/action-k3s-helm/releases.
+name: Release updates
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  actions-tagger:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      # Action reference: https://github.com/Actions-R-Us/actions-tagger
+      - uses: Actions-R-Us/actions-tagger@v2
+        with:
+          token: "${{ github.token }}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+# How to make a release
+
+This action is published to the [GitHub Actions Marketplace](https://github.com/marketplace/actions/get-anaconda-package-version).
+
+To make a release you need push rights to the [jacobtomlinson/gha-anaconda-package-version GitHub repository](https://github.com/jacobtomlinson/gha-anaconda-package-version).
+
+## Steps to make a release
+
+1. Create a new _GitHub release_ by clicking on `Draft a new release` at
+   https://github.com/jacobtomlinson/gha-anaconda-package-version/releases and
+   creating a new tag for `master`. Remember to prefix the tag with `v`, e.g.
+   `v1.0.5`
+
+1. Check everything again, then click `Publish release`.
+   This will create a tag, and trigger a CI action to update tags like `v1`.


### PR DESCRIPTION
This is a practice adopted in several actions I've actively contributed to maintaining in the jupyterhub org, and it has been working great for a few years now without any maintenance requirements for the added automation either.

With this automation, cutting a `v1.2.3` release for example leads to updating a `v1` tag as well, and that allows people to pin to `v1` instead of `v1.2.3` etc.