### PR TITLE
Set GitHub output via env var instead of stdout

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Check outputs
         run: |
           echo "${{ steps.selftest-semver.outputs.version }}"
+          if [ "${{ steps.selftest-semver.outputs.version }}" = "" ];then
+            echo "Version is empty"
+            exit 1
+          fi
 
       - name: Self test
         id: selftest-calver
@@ -28,3 +32,7 @@ jobs:
       - name: Check outputs
         run: |
           echo "${{ steps.selftest-calver.outputs.version }}"
+          if [ "${{ steps.selftest-calver.outputs.version }}" = "" ];then
+            echo "Version is empty"
+            exit 1
+          fi

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   package:
     description: The Python package name
     required: true
+  version_system:
+    description: The versioning system to use
+    required: false
+    default: "SemVer"
 outputs:
   version:
     description: The latest version

--- a/main.go
+++ b/main.go
@@ -25,6 +25,21 @@ func getEnvDefault(key, default_value string) string {
 	return default_value
 }
 
+func writeOutput(key, value string) error {
+	output_filename := os.Getenv("GITHUB_OUTPUT")
+	f, err := os.OpenFile(output_filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	if _, err = f.WriteString(fmt.Sprintf(`%s=%s`, key, value)); err != nil {
+		return err
+	}
+	return nil
+}
+
 func main() {
 
 	var semtags []*semver.Version
@@ -81,7 +96,10 @@ func main() {
 		if len(semtags) == 0 {
 			log.Fatal(fmt.Sprintf(`Unable to find files for %s/%s`, orgName, pkgName))
 		}
-		os.Setenv("GITHUB_OUTPUT", fmt.Sprintf(`version=%s`, semtags[len(semtags)-1]))
+		writeErr := writeOutput("version", fmt.Sprintf(`%s`, semtags[len(semtags)-1]))
+		if writeErr != nil {
+			log.Fatal(readErr)
+		}
 
 	} else { // CalVer
 		for _, tag := range pkg {
@@ -95,7 +113,9 @@ func main() {
 		if len(caltags) == 0 {
 			log.Fatal(fmt.Sprintf(`Unable to find files for %s/%s`, orgName, pkgName))
 		}
-
-		os.Setenv("GITHUB_OUTPUT", fmt.Sprintf(`version=%s`, caltags[len(caltags)-1]))
+		writeErr := writeOutput("version", fmt.Sprintf(`%s`, caltags[len(caltags)-1]))
+		if writeErr != nil {
+			log.Fatal(readErr)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -19,10 +19,10 @@ type PkgFile struct {
 }
 
 func getEnvDefault(key, default_value string) string {
-    if val, found := os.LookupEnv(key); found {
-        return val
-    }
-    return default_value
+	if val, found := os.LookupEnv(key); found {
+		return val
+	}
+	return default_value
 }
 
 func main() {
@@ -64,14 +64,16 @@ func main() {
 		log.Fatal(unmarshalErr)
 	}
 
-	if (verSys == "SemVer") {
+	if verSys == "SemVer" {
 		for _, tag := range pkg {
 			matched, _ := regexp.MatchString(`.*\..*\..*`, tag.Version)
 			if matched {
 				version, semverErr := semver.NewVersion(tag.Version)
 				if semverErr == nil {
 					semtags = append(semtags, version)
-				} else {fmt.Println("incompatible semver found:", tag.Version, semverErr)}
+				} else {
+					fmt.Println("incompatible semver found:", tag.Version, semverErr)
+				}
 			}
 		}
 		semver.Sort(semtags)
@@ -79,10 +81,9 @@ func main() {
 		if len(semtags) == 0 {
 			log.Fatal(fmt.Sprintf(`Unable to find files for %s/%s`, orgName, pkgName))
 		}
+		os.Setenv("GITHUB_OUTPUT", fmt.Sprintf(`version=%s`, semtags[len(semtags)-1]))
 
-		fmt.Println(fmt.Sprintf(`::set-output name=version::%s`, semtags[len(semtags)-1]))
-
-	} else {  // CalVer
+	} else { // CalVer
 		for _, tag := range pkg {
 			matched, _ := regexp.MatchString(`.*\..*\..*`, tag.Version)
 			if matched {
@@ -95,7 +96,6 @@ func main() {
 			log.Fatal(fmt.Sprintf(`Unable to find files for %s/%s`, orgName, pkgName))
 		}
 
-		fmt.Println(fmt.Sprintf(`::set-output name=version::%s`, caltags[len(caltags)-1]))
-
+		os.Setenv("GITHUB_OUTPUT", fmt.Sprintf(`version=%s`, caltags[len(caltags)-1]))
 	}
 }


### PR DESCRIPTION
Following the migration guide from https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ to set outputs via env vars instead of stdout.